### PR TITLE
Make it possible to encode a portion of the buffer

### DIFF
--- a/lib/base64-arraybuffer.js
+++ b/lib/base64-arraybuffer.js
@@ -16,8 +16,8 @@
     lookup[chars.charCodeAt(i)] = i;
   }
 
-  exports.encode = function(arraybuffer) {
-    var bytes = new Uint8Array(arraybuffer),
+  exports.encode = function(arraybuffer, offset, length) {
+    var bytes = new Uint8Array(arraybuffer, offset || 0, length !== undefined ? length : arraybuffer.byteLength),
     i, len = bytes.length, base64 = "";
 
     for (i = 0; i < len; i+=3) {


### PR DESCRIPTION
If you want to encode a TypedArray, such as a Float64Array, Uint16Array or so, it can be backed by just a portion of an ArrayBuffer. If wanting to encode such a TypedArray without having to copy the portion into a new buffer, the encode function should take an offset and a length.

Example

``` js
var buffer = new ArrayBuffer(65536);
...fill buffer with something...

// Create a Uint16 view of portion of bytes between [1024...2047]:
var array = new Uint16Array(buffer, 1024, 512); // 512 = length in 16-bit units.

// Base64 encode that portion:
encode (array.buffer, array.byteOffset, array.byteLength);

```
