### PR TITLE
Use standard MIT license with SPDX identifier only

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/niklasvh/base64-arraybuffer/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/niklasvh/base64-arraybuffer/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "lib/base64-arraybuffer",
   "engines": {
     "node": ">= 0.6.0"


### PR DESCRIPTION
Per https://docs.npmjs.com/files/package.json#license the `licenses` format is deprecated.

This causes problems with tools that build license meta-data from `package.json`.

Thanks!