### PR TITLE
Reduce lookup size

### DIFF
--- a/lib/base64-arraybuffer.js
+++ b/lib/base64-arraybuffer.js
@@ -11,7 +11,7 @@
   var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
   // Use a lookup table to find the index.
-  var lookup = new Uint8Array(256);
+  var lookup = new Uint8Array(123); // max ASCII code in chars is 122
   for (var i = 0; i < chars.length; i++) {
     lookup[chars.charCodeAt(i)] = i;
   }


### PR DESCRIPTION
b64 chars are between 43 & 122.